### PR TITLE
Version 9.4.1

### DIFF
--- a/app/Http/Controllers/MainController.php
+++ b/app/Http/Controllers/MainController.php
@@ -6630,7 +6630,7 @@ class MainController extends Controller
 			
 			// get schedule production order against $schedule_date
 			$scheduled_production = DB::connection('mysql_mes')->table('production_order')
-				->whereNotIn('status', ['Cancelled'])->whereDate('planned_start_date', $schedule_date)
+				->whereNotIn('status', ['Cancelled', 'Closed'])->whereDate('planned_start_date', $schedule_date)
 				->where('operation_id', $operation)->whereRaw('feedback_qty < qty_to_manufacture');
 
 			// get pending backlogs before $schedule_date
@@ -6705,7 +6705,7 @@ class MainController extends Controller
 		$assigned_production = DB::connection('mysql_mes')->table('assembly_conveyor_assignment')->get();
 
         $unassigned_production = DB::connection('mysql_mes')->table('production_order')
-            ->where('operation_id', $operation_id)
+            ->where('operation_id', $operation_id)->whereNotIn('status', ['Cancelled', 'Closed', 'Feedbacked', 'Completed'])
             ->whereNotIn('production_order', array_column($assigned_production->toArray(), 'production_order'))
             ->where('planned_start_date', $scheduled_date)->get();
 
@@ -6720,7 +6720,7 @@ class MainController extends Controller
             // get scheduled production order against $scheduled_date
             $q = DB::connection('mysql_mes')->table('assembly_conveyor_assignment as aca')
                 ->join('production_order as po', 'aca.production_order', 'po.production_order')
-                ->whereNotIn('po.status', ['Cancelled'])
+                ->whereNotIn('po.status', ['Cancelled', 'Closed'])
                 ->whereDate('scheduled_date', $scheduled_date)->where('machine_code', $machine->machine_code)
                 ->select('aca.*', 'po.sales_order', 'po.material_request', 'po.sales_order', 'po.material_request', 'po.qty_to_manufacture', 'po.item_code', 'po.stock_uom', 'po.status', 'po.description', 'po.classification')
                 ->orderBy('aca.order_no', 'asc')->orderBy('aca.scheduled_date', 'asc');

--- a/app/Http/Controllers/MainController.php
+++ b/app/Http/Controllers/MainController.php
@@ -6722,7 +6722,7 @@ class MainController extends Controller
                 ->join('production_order as po', 'aca.production_order', 'po.production_order')
                 ->whereNotIn('po.status', ['Cancelled'])
                 ->whereDate('scheduled_date', $scheduled_date)->where('machine_code', $machine->machine_code)
-                ->select('aca.*', 'po.sales_order', 'po.material_request', 'po.sales_order', 'po.material_request', 'po.qty_to_manufacture', 'po.item_code', 'po.stock_uom', 'po.status', 'po.description')
+                ->select('aca.*', 'po.sales_order', 'po.material_request', 'po.sales_order', 'po.material_request', 'po.qty_to_manufacture', 'po.item_code', 'po.stock_uom', 'po.status', 'po.description', 'po.classification')
                 ->orderBy('aca.order_no', 'asc')->orderBy('aca.scheduled_date', 'asc');
 
             // get scheduled production order before $scheduled_date
@@ -6730,7 +6730,7 @@ class MainController extends Controller
                 ->join('production_order as po', 'aca.production_order', 'po.production_order')
                 ->whereIn('po.status', ['In Progress', 'Not Started'])
                 ->whereDate('scheduled_date', '<', $scheduled_date)->where('machine_code', $machine->machine_code)
-                ->select('aca.*', 'po.sales_order', 'po.material_request', 'po.sales_order', 'po.material_request', 'po.qty_to_manufacture', 'po.item_code', 'po.stock_uom', 'po.status', 'po.description')
+                ->select('aca.*', 'po.sales_order', 'po.material_request', 'po.sales_order', 'po.material_request', 'po.qty_to_manufacture', 'po.item_code', 'po.stock_uom', 'po.status', 'po.description', 'po.classification')
                 ->orderBy('aca.order_no', 'asc')->orderBy('aca.scheduled_date', 'asc');
 
             // get scheduled production order before $scheduled_date
@@ -6739,7 +6739,7 @@ class MainController extends Controller
                 ->whereIn('po.status', ['Completed'])
                 ->whereBetween('po.actual_end_date', [$start, $end])
                 ->whereDate('scheduled_date', '<', $scheduled_date)->where('machine_code', $machine->machine_code)
-                ->select('aca.*', 'po.sales_order', 'po.material_request', 'po.sales_order', 'po.material_request', 'po.qty_to_manufacture', 'po.item_code', 'po.stock_uom', 'po.status', 'po.description')
+                ->select('aca.*', 'po.sales_order', 'po.material_request', 'po.sales_order', 'po.material_request', 'po.qty_to_manufacture', 'po.item_code', 'po.stock_uom', 'po.status', 'po.description', 'po.classification')
                 ->orderBy('aca.order_no', 'asc')->orderBy('aca.scheduled_date', 'asc')
                 ->union($q)->union($q1)->get();
 

--- a/resources/views/production_schedule_monitoring.blade.php
+++ b/resources/views/production_schedule_monitoring.blade.php
@@ -215,6 +215,7 @@
                               <span class="d-block font-weight-bold" style="font-size: 10pt;">{{ $row->production_order }} [{{ $row->sales_order }}{{ $row->material_request }}]</span>
                               <span class="d-block mt-1">{{ $row->item_code }} [{{ $row->qty_to_manufacture }} {{ $row->stock_uom }}]</span>
                               <span class="d-block" style="font-size: 9pt;">{{ strtok($row->description, ',') }}</span>
+                              <span class="d-block mt-1 font-weight-bold" style="font-size: 8pt;">{{ ($row->classification) }}</span>
                             </div>
                           </div>
                           @endforeach
@@ -251,6 +252,7 @@
                                   <span class="d-block font-weight-bold" style="font-size: 10pt;">{{ $row->production_order }} [{{ $row->sales_order }}{{ $row->material_request }}]</span>
                                   <span class="d-block mt-1">{{ $row->item_code }} [{{ $row->qty_to_manufacture }} {{ $row->stock_uom }}]</span>
                                   <span class="d-block" style="font-size: 9pt;">{{ strtok($row->description, ',') }}</span>
+                                  <span class="d-block mt-1 font-weight-bold" style="font-size: 8pt;">{{ ($row->classification) }}</span>
                                 </div>
                               </div>
                               @endforeach

--- a/resources/views/tables/tbl_conveyor_schedule.blade.php
+++ b/resources/views/tables/tbl_conveyor_schedule.blade.php
@@ -13,25 +13,30 @@
 			<div class="col-md-12 p-1">
 				<div class="table-responsive pr-1 pl-1" style="max-height: 580px;">
 					<table class="table table-bordered table-condensed">
+						<col style="width: 8%;">
 						<col style="width: 15%;">
+						<col style="width: 22%;">
 						<col style="width: 25%;">
-						<col style="width: 30%;">
 						<col style="width: 10%;">
 						<col style="width: 10%;">
 						<col style="width: 10%;">
 						<thead class="text-uppercase font-weight-bold" style="font-size: 9pt;">
 							<tr>
-							<td class="text-center">Prod. Order</td>
-							<td class="text-center">Customer</td>
-							<td class="text-center">Item Details</td>
-							<td class="text-center">Qty</td>
-							<td class="text-center">Good</td>
-							<td class="text-center">Bal.</td>
-						</tr>
+								<td class="text-center">Priority</td>
+								<td class="text-center">Prod. Order</td>
+								<td class="text-center">Customer</td>
+								<td class="text-center">Item Details</td>
+								<td class="text-center">Qty</td>
+								<td class="text-center">Good</td>
+								<td class="text-center">Bal.</td>
+							</tr>
 						</thead>
 						<tbody style="font-size: 8pt;">
 							@forelse ($row['production_orders'] as $r)
 							<tr>
+								<td class="text-center align-middle">
+									<h4 class="m-0 font-weight-bold">{{ $r['order_no'] }}</h4>
+								</td>
 								<td class="text-center font-weight-bold">
 									@php
 										if($r['status'] == 'Not Started'){
@@ -48,6 +53,7 @@
 									<span class="d-block font-weight-bold">{{ $r['reference_no'] }}</span>
 									<span class="d-block">{{ $r['customer'] }}</span>
 									<span class="d-block">Project: {{ $r['project'] }}</span>
+									<span class="d-block mt-1 font-weight-bold">{{ $r['classification'] }}</span>
 								</td>
 								<td class="text-justify">
 									<span class="font-weight-bold">{{ $r['item_code'] }}</span> - 

--- a/resources/views/tables/tbl_conveyor_schedule.blade.php
+++ b/resources/views/tables/tbl_conveyor_schedule.blade.php
@@ -13,16 +13,16 @@
 			<div class="col-md-12 p-1">
 				<div class="table-responsive pr-1 pl-1" style="max-height: 580px;">
 					<table class="table table-bordered table-condensed">
-						<col style="width: 8%;">
+						<col style="width: 5%;">
 						<col style="width: 15%;">
-						<col style="width: 22%;">
+						<col style="width: 25%;">
 						<col style="width: 25%;">
 						<col style="width: 10%;">
 						<col style="width: 10%;">
 						<col style="width: 10%;">
 						<thead class="text-uppercase font-weight-bold" style="font-size: 9pt;">
 							<tr>
-								<td class="text-center">Priority</td>
+								<td class="text-center">No.</td>
 								<td class="text-center">Prod. Order</td>
 								<td class="text-center">Customer</td>
 								<td class="text-center">Item Details</td>


### PR DESCRIPTION
# Release notes - Manufacturing Execution System - Version Version 9.4.1

### Bug

[MES-1078](https://fumacoinc.atlassian.net/browse/MES-1078) Priority number is not updating upon dragging in machine scheduling for production staff

[MES-1077](https://fumacoinc.atlassian.net/browse/MES-1077) Production Order per machine is not ordered based on priority for operator

### Story

[MES-1085](https://fumacoinc.atlassian.net/browse/MES-1085) Add column priority number of production orders in machine scheduling for operator \(Operator Dashboard\)

[MES-1083](https://fumacoinc.atlassian.net/browse/MES-1083) Hide "Closed" Production Order in production scheduling/machine scheduling

[MES-1079](https://fumacoinc.atlassian.net/browse/MES-1079) Display Order Type of per production order in machine scheduling for production staff